### PR TITLE
Remove Jenkins test harness from hpi file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,21 +8,6 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-cps</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-job</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-step-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,6 @@
             <version>2.277.1</version>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-test-harness-htmlunit</artifactId>
-            <version>66.v712ea44bccba</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
             <version>2.24</version>
@@ -55,6 +49,11 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.11.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-lang3-api</artifactId>
+            <version>3.12.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
## Replace Jenkins test harness in hpi with Apache commons lang3 plugin

https://github.com/jenkinsci/jenkins/pull/8714 included in Jenkins 2.434 and later will refuse to load a plugin that includes the Jenkins test harness.

The Jenkins test harness causes unexpected failures when it is included in a Jenkins plugin.  Refer to the following issue reports for examples:

* https://issues.jenkins.io/browse/JENKINS-65650
* https://issues.jenkins.io/browse/JENKINS-66060
* https://issues.jenkins.io/browse/JENKINS-72353

The additional benefit of the change is that it makes the plugin hpi file over 90% smaller.

Before this change, the plugin hpi file had the following contents:

```
  1680 images/docker.svg
   765 META-INF/MANIFEST.MF
    84 META-INF/maven/io.jenkins.plugins/container-image-link/pom.properties
  5342 META-INF/maven/io.jenkins.plugins/container-image-link/pom.xml
327135 WEB-INF/lib/commons-io-2.11.0.jar
307305 WEB-INF/lib/commons-net-3.8.0.jar
 13633 WEB-INF/lib/container-image-link.jar
  9277 WEB-INF/lib/crypto-util-1.5.jar
 98115 WEB-INF/lib/dec-0.1.2.jar
10579074 WEB-INF/lib/jenkins-test-harness-htmlunit-66.v712ea44bccba.jar
 65728 WEB-INF/lib/salvation2-3.0.0.jar
276420 WEB-INF/lib/serializer-2.7.2.jar
220536 WEB-INF/lib/xml-apis-1.4.01.jar
  6546 WEB-INF/licenses.xml
```

After this change, the plugin hpi file has the following contents:

```
  1680 images/docker.svg
   816 META-INF/MANIFEST.MF
    83 META-INF/maven/io.jenkins.plugins/container-image-link/pom.properties
  5320 META-INF/maven/io.jenkins.plugins/container-image-link/pom.xml
327135 WEB-INF/lib/commons-io-2.11.0.jar
 13661 WEB-INF/lib/container-image-link.jar
  9277 WEB-INF/lib/crypto-util-1.5.jar
  3444 WEB-INF/licenses.xml
```

Also removes duplicate dependency declarations.

Replacement for PR closed when I deleted my fork of the repository:

* https://github.com/jenkinsci/container-image-link-plugin/pull/110

### Testing done

Automated tests pass.  Confirmed that the plugin does not load in Jenkins 2.492.3 without this change.  Confirmed that the plugin loads in Jenkins 2.492.3 with this change..

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
